### PR TITLE
Reopen

### DIFF
--- a/ModuleData/tow_abilities.xml
+++ b/ModuleData/tow_abilities.xml
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0"?>
 <ArrayOfCharacterAbilityTuple xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
   <!-- custom battle lords -->
   <CharacterAbilityTuple CharacterID="emp_lord">
     <Abilities>Fireball</Abilities>


### PR DESCRIPTION
- adjusted CrosshairMissionBehavior and AbilityManagerMissionBehavior logics;
- improved SpecialMove logic and fixed issue when player was able to go through town walls while used SpecialMove;

Currently there is only one SpecialMove and it's ShadowStep is avaliable for vampire player from the start. Press Cntrl to use it, cooldown - 60 seconds.