### PR TITLE
Fixed Wanderers crash if Culture is not owning any settlement

### DIFF
--- a/CSharpSourceCode/CampaignSupport/TORWanderersCampaignBehavior.cs
+++ b/CSharpSourceCode/CampaignSupport/TORWanderersCampaignBehavior.cs
@@ -52,7 +52,8 @@ namespace TOW_Core.CampaignSupport
                     var suitableTown = (from x in Town.AllTowns
                                         where x.Settlement.Culture == wanderer.Culture
                                         orderby x.Settlement.HeroesWithoutParty.Count ascending
-                                        select x).FirstOrDefault().Settlement;
+                                        select x).FirstOrDefault()
+                        ?.Settlement;
                     if (suitableTown != null)
                     {
                         EnterSettlementAction.ApplyForCharacterOnly(wanderer, suitableTown);


### PR DESCRIPTION
Settlements could be null, in case no settlement was left. Therefore this was leading to a crash