### PR TITLE
Rework gunpowder logic

### DIFF
--- a/CSharpSourceCode/Battle/BlackPowderWeapon/BlackPowderWeaponMissionLogic.cs
+++ b/CSharpSourceCode/Battle/BlackPowderWeapon/BlackPowderWeaponMissionLogic.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using TaleWorlds.Engine;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
@@ -51,24 +51,11 @@ namespace TOW_Core.Battle.FireArms
                     int selected = this._random.Next(0, this._soundIndex.Length - 1);
                     Mission.MakeSound(this._soundIndex[selected], position, false, true, -1, -1);
                 }
-                // alarm enemies if it's hideout mission
-                if (!areEnemiesAlarmed)
-                {
-                    areEnemiesAlarmed = true;
-                    var spawnLogic = Mission.Current.GetMissionBehavior<HideoutMissionController>();
-                    if (spawnLogic != null)
-                    {
-                        foreach (var agent in base.Mission.PlayerEnemyTeam.TeamAgents)
-                        {
-                            spawnLogic.OnAgentAlarmedStateChanged(agent, Agent.AIStateFlag.Alarmed);
-                            agent.SetWatchState(Agent.WatchState.Alarmed);
-                        }
-                    }
-                }
+              
                 // run firearms script
                 if (shooterAgent.WieldedWeapon.Item.StringId.Contains("blunderbuss"))
                 {
-                    if ((shooterAgent.WieldedWeapon.CurrentUsageItem.WeaponClass == WeaponClass.Boulder))
+                    if (shooterAgent.WieldedWeapon.AmmoWeapon.Item.StringId.Contains("grenade"))
                     {
                         Mission.Missile grenade = Mission.Missiles.FirstOrDefault(m => m.ShooterAgent == shooterAgent &&
                                                                m.Weapon.Item.StringId.Contains("ammo_grenade") &&

--- a/CSharpSourceCode/Battle/BlackPowderWeapon/BlackPowderWeaponMissionLogic.cs
+++ b/CSharpSourceCode/Battle/BlackPowderWeapon/BlackPowderWeaponMissionLogic.cs
@@ -68,7 +68,7 @@ namespace TOW_Core.Battle.FireArms
                 // run firearms script
                 if (shooterAgent.WieldedWeapon.Item.StringId.Contains("blunderbuss"))
                 {
-                    if (shooterAgent.WieldedWeapon.AmmoWeapon.Item.StringId.Contains("grenade"))
+                    if ((shooterAgent.WieldedWeapon.CurrentUsageItem.WeaponClass == WeaponClass.Boulder))
                     {
                         Mission.Missile grenade = Mission.Missiles.FirstOrDefault(m => m.ShooterAgent == shooterAgent &&
                                                                m.Weapon.Item.StringId.Contains("ammo_grenade") &&
@@ -79,6 +79,7 @@ namespace TOW_Core.Battle.FireArms
                         }
                     }
                     else
+                    if(shooterAgent.WieldedWeapon.CurrentUsageItem.WeaponClass == WeaponClass.Crossbow)
                     {
                         DoShotgunShot(shooterAgent, position, orientation, 4);
                     }
@@ -107,6 +108,9 @@ namespace TOW_Core.Battle.FireArms
             {
                 weapon = shooterAgent.Equipment[index];
                 // Weapon hit points mean amount of ammo
+                if(weapon.CurrentUsageItem==null)
+                    continue;
+                
                 if (weapon.CurrentUsageItem.WeaponClass == shooterAgent.WieldedWeapon.CurrentUsageItem.AmmoClass && weapon.HitPoints > 0)
                 {
                     foundAmmoAmount += Math.Min(requiredAmmoAmount, weapon.HitPoints);

--- a/CSharpSourceCode/Battle/BlackPowderWeapon/BlackPowderWeaponMissionLogic.cs
+++ b/CSharpSourceCode/Battle/BlackPowderWeapon/BlackPowderWeaponMissionLogic.cs
@@ -14,16 +14,16 @@ namespace TOW_Core.Battle.FireArms
         private int[] _soundIndex = new int[5];
         private Random _random;
         private bool areEnemiesAlarmed = false;
-        
+
         public BlackPowderWeaponMissionLogic()
         {
             for (int i = 0; i < 5; i++)
             {
                 this._soundIndex[i] = SoundEvent.GetEventIdFromString("musket_fire_sound_" + (i + 1));
             }
+
             this._random = new Random();
         }
-        
 
         private void CreateSmokeParticles(MatrixFrame frame, string particleEffectId)
         {
@@ -38,251 +38,138 @@ namespace TOW_Core.Battle.FireArms
                 Mission.MakeSound(this._soundIndex[selected], position, false, true, -1, -1);
             }
         }
-        
 
-        public override void OnAgentShootMissile(Agent shooterAgent, EquipmentIndex weaponIndex, Vec3 position, Vec3 velocity, Mat3 orientation, bool hasRigidBody, int forcedMissileIndex)
+        public override void OnAgentShootMissile(Agent shooterAgent, EquipmentIndex weaponIndex, Vec3 position,
+            Vec3 velocity, Mat3 orientation, bool hasRigidBody, int forcedMissileIndex)
         {
             var itemUsage = shooterAgent.WieldedWeapon.CurrentUsageItem.ItemUsage;
-            
+            var succesfulShot = false;
             if (itemUsage.Contains("handgun") || itemUsage.Contains("pistol"))
             {
-                var frame = new MatrixFrame(orientation, position);
-                frame.Advance((float)(shooterAgent.WieldedWeapon.CurrentUsageItem.WeaponLength/100));
-                CreateSmokeParticles(frame,"handgun_shoot_2");
-                CreateMuzzleFireSound(position);
-              
                 // run firearms script
                 if (shooterAgent.WieldedWeapon.Item.StringId.Contains("blunderbuss"))
                 {
-                    DoShotgunShot(shooterAgent,weaponIndex, position, orientation, 6, 4);
+                    succesfulShot = TryShotgunShot(shooterAgent, weaponIndex, position, orientation, 6, 4);
                 }
-                else if (shooterAgent.WieldedWeapon.Item.StringId.Contains("two_barrels"))
+                else
                 {
-                    DoTwoBarrelsShot(shooterAgent, position, orientation);
+                    succesfulShot = true; //no requirement regular guns logic
                 }
-                else if (shooterAgent.WieldedWeapon.Item.StringId.Contains("four_barrels"))
+
+                if (succesfulShot)
                 {
-                    DoFourBarrelsShot(shooterAgent, position, orientation);
+                    var frame = new MatrixFrame(orientation, position);
+                    frame.Advance((float)((shooterAgent.WieldedWeapon.CurrentUsageItem.WeaponLength + 20) / 100));
+                    CreateSmokeParticles(frame, "handgun_shoot_2");
+                    CreateMuzzleFireSound(position);
+                }
+                else
+                {
+                    SkipReloadPhase(shooterAgent, weaponIndex);
                 }
             }
         }
 
-
-
-        private bool ConsumeAmmoOfAgent(int amount, Agent agent, WeaponClass ammoType)
+        private bool CanConsumeAmmoOfAgent(int amount, Agent agent, WeaponClass ammoType)
         {
             MissionEquipment equipment = agent.Equipment;
-
             var d = agent.WieldedWeapon.CurrentUsageIndex;
-            
-            
-
-            EquipmentIndex equipmentIndex =(EquipmentIndex) equipment.GetAmmoSlotIndexOfWeapon(ammoType);
-
+            EquipmentIndex equipmentIndex = (EquipmentIndex)equipment.GetAmmoSlotIndexOfWeapon(ammoType);
             var currentAmmo = equipment.GetAmmoAmount(ammoType);
-
             if (currentAmmo >= amount)
             {
                 short newAmount = (short)(currentAmmo - amount);
-                //equipment.SetHitPointsOfSlot(equipmentIndex,newAmount);
-                //equipment.SetHitPointsOfSlot((EquipmentIndex)d,newAmount);
-                //equipment.SetAmountOfSlot((EquipmentIndex)d, newAmount,false);
-                //equipment.SetAmountOfSlot(equipmentIndex,newAmount,false);
-               //equipment.SetConsumedAmmoOfSlot(equipmentIndex, (short) amount);
-                //agent.WieldedWeapon.ConsumeAmmo((short)amount);
-                
-                agent.SetWeaponAmountInSlot(equipmentIndex,newAmount,false);
-               // agent.WieldedWeapon.AmmoWeapon.ConsumeAmmo();
+                agent.SetWeaponAmountInSlot(equipmentIndex, newAmount, false);
                 return true;
             }
 
             return false;
         }
 
+        private void SkipReloadPhase(Agent agent, EquipmentIndex index)
+        {
+            //this script seem not work as intended the reload phase is not automatically finalized.
+            MissionEquipment equipment = agent.Equipment;
+            equipment.SetReloadPhaseOfSlot(index, agent.WieldedWeapon.ReloadPhaseCount);
+        }
+
         private void RestoreAmmo(Agent agent, WeaponClass ammoType)
         {
             MissionEquipment equipment = agent.Equipment;
-            EquipmentIndex equipmentIndex =(EquipmentIndex) equipment.GetAmmoSlotIndexOfWeapon(ammoType);
-            short restoredAmmo = (short) (equipment.GetAmmoAmount(ammoType)+1);
-            agent.SetWeaponAmountInSlot(equipmentIndex,restoredAmmo,false);
+            EquipmentIndex equipmentIndex = (EquipmentIndex)equipment.GetAmmoSlotIndexOfWeapon(ammoType);
+            short restoredAmmo = (short)(equipment.GetAmmoAmount(ammoType) + 1);
+            agent.SetWeaponAmountInSlot(equipmentIndex, restoredAmmo, false);
+        }
+
+        private bool TryShotgunShot(Agent shooterAgent, EquipmentIndex weaponIndex, Vec3 shotPosition,
+            Mat3 shotOrientation, short scatterShots, short requiredAmmoAmount)
+        {
+            MissionWeapon weaponAtIndex = shooterAgent.Equipment[weaponIndex];
+            var weaponData = weaponAtIndex.CurrentUsageItem;
+            if (weaponData != null && weaponAtIndex.CurrentUsageItem.IsRangedWeapon)
+            {
+                RemoveLastProjectile(shooterAgent);
+                RestoreAmmo(shooterAgent, weaponData.AmmoClass);
+                if (!weaponAtIndex.AmmoWeapon.IsEmpty)
+                {
+                    var accuracy = 1f / (weaponData.Accuracy * 1.2f); //this should be definable via XML or other data format.
+                    if (CanConsumeAmmoOfAgent(requiredAmmoAmount, shooterAgent, weaponData.AmmoClass))
+                    {
+                        ScatterShot(shooterAgent, accuracy, weaponAtIndex.AmmoWeapon, shotPosition, shotOrientation, weaponData.MissileSpeed, scatterShots);
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         /// <summary>
-        /// The script will check each ammo weapon (that fits current usage of shooter's weapon) for bullets to do blunderbuss shot. 
-        /// It can use multiple ammo weapons to collect required amount of bullets.
+        /// Allows to Create a scattered shot with several projectiles at a given position.
         /// </summary>
-        /// <param name="requiredAmmoAmount">Max amount of bullets to do blunderbuss shot.</param>
-        ///
-        ///
-        private void DoShotgunShot(Agent shooterAgent,EquipmentIndex weaponIndex,Vec3 shotPosition ,Mat3 shotOrientation, short scatterShots, short requiredAmmoAmount)
+        public void ScatterShot(Agent shooterAgent, float accuracy, MissionWeapon projectileType, Vec3 shotPosition,
+            Mat3 shotOrientation, float missleSpeed,short scatterShotAmount)
         {
-            MissionWeapon weaponAtIndex = shooterAgent.Equipment[weaponIndex];
-
-            var weaponData = weaponAtIndex.CurrentUsageItem;
-            
-            if (weaponData!=null&&weaponAtIndex.CurrentUsageItem.IsRangedWeapon)
+            for (int i = 0; i < scatterShotAmount; i++)
             {
-            
-                RemoveLastProjectile(shooterAgent);
-                RestoreAmmo(shooterAgent,weaponData.AmmoClass);
-                if (!weaponAtIndex.AmmoWeapon.IsEmpty)
-                {
-                    var accuracy = 1f / (weaponData.Accuracy * 1.2f);
-                    /*MissionEquipment equipment = shooterAgent.Equipment;
-                    var t = equipment.GetAmmoAmount(weaponData.AmmoClass);
-                    EquipmentIndex index = (EquipmentIndex) equipment.GetAmmoSlotIndexOfWeapon(weaponData.AmmoClass);
-                    equipment.SetHitPointsOfSlot(index,(short) (equipment[index].HitPoints- requiredAmmoAmount));*/
-
-                    if (ConsumeAmmoOfAgent(requiredAmmoAmount, shooterAgent, weaponData.AmmoClass))
-                    {
-                        ScatterShot(shooterAgent,accuracy,weaponAtIndex.AmmoWeapon,shotPosition,shotOrientation,scatterShots, 1.2f,weaponData.MissileSpeed);
-                    }
-                }
-               
-                
-                /*float scattering = 1f / (weaponData.Accuracy * 1.2f);
-                while (foundAmmoAmount > 0)
-                {
-                    foundAmmoAmount--;
-                    var _orientation = GetRandomOrientation(shotOrientation, scattering);
-                    Mission.AddCustomMissile(shooterAgent, weapon, shotPosition, _orientation.f, _orientation, weaponData.MissileSpeed, weaponData.MissileSpeed, false, null);
-                }
-              
-                
-                if (foundAmmoAmount == requiredAmmoAmount)
-                {
-                            
-                    
-                }
-                TOWCommon.Say(ammo.ToString());*/
+                var deviation = GetRandomOrientation(shotOrientation, accuracy);
+                Mission.AddCustomMissile(shooterAgent, projectileType, shotPosition, deviation.f, deviation,
+                    missleSpeed, missleSpeed, false, null);
             }
         }
-        
-        
-
-
-        private void ScatterShot(Agent shooterAgent, float accuracy, MissionWeapon ammo, Vec3 shotPosition, Mat3 shotOrientation, short scatterShots, float scatteringDeviation, float missleSpeed)
-        {
-            for (int i = 0; i < scatterShots; i++)
-            {
-                var deviation  = GetRandomOrientation(shotOrientation, accuracy);
-                Mission.AddCustomMissile(shooterAgent, ammo, shotPosition, deviation.f, deviation, missleSpeed, missleSpeed, false, null);
-            }
-        }
-
-        /*private void SetAmmunition(Agent shooterAgent, MissionWeapon rangedWeapon, short ammo, bool IsLoaded)
-        {
-            shooterAgent.Character.Equipment.GetEquipmentFromSlot()
-            var ammoIndex = rangedWeapon.AmmoWeapon.CurrentUsageIndex;
-            var lastStage = rangedWeapon.ReloadPhaseCount;
-            shooterAgent.SetReloadAmmoInSlot(index,ammoIndex,ammo);
-            shooterAgent.SetWeaponReloadPhaseAsClient(index, lastStage);
-            rangedWeapon.;
-        }*/
 
         private void RemoveLastProjectile(Agent shooterAgent)
         {
-            var falseMissle= Mission.Missiles.FirstOrDefault(missle => missle.ShooterAgent == shooterAgent);
-                        
-                if(falseMissle!=null)
-                    Mission.RemoveMissileAsClient(falseMissle.Index);
+            var falseMissle = Mission.Missiles.FirstOrDefault(missle => missle.ShooterAgent == shooterAgent);
+            if (falseMissle != null) Mission.RemoveMissileAsClient(falseMissle.Index);
         }
-        private void DoShotgunShot(Agent shooterAgent, Vec3 shotPosition, Mat3 shotOrientation, short requiredAmmoAmount, WeaponClass ammoType =WeaponClass.Cartridge)
-        {
-            short foundAmmoAmount = 0;
-            
-           
-            for (EquipmentIndex index = EquipmentIndex.WeaponItemBeginSlot; index < EquipmentIndex.NumAllWeaponSlots; index++)
-            {
-                var weapon = shooterAgent.Equipment[index];
-
-               
-                
-                if (weapon.CurrentUsageItem!=null && weapon.CurrentUsageItem.WeaponClass == ammoType)
-                {
-                    WeaponComponentData weaponData = shooterAgent.WieldedWeapon.CurrentUsageItem;
-                    // Weapon hit points mean amount of ammo
-
-                    if (weapon.CurrentUsageItem.WeaponClass == WeaponClass.Cartridge && weapon.HitPoints > 0)
-                    {
-                        foundAmmoAmount += Math.Min(requiredAmmoAmount, weapon.HitPoints);
-                        short newAmount = (short)(weapon.HitPoints - Math.Min(foundAmmoAmount, weapon.HitPoints));
-                        
-                       // shooterAgent.SetReloadAmmoInSlot(index,);
-                        shooterAgent.SetWeaponAmountInSlot(index, newAmount, false);
-                        if (foundAmmoAmount == requiredAmmoAmount)
-                        {
-                            
-                            float scattering = 1f / (weaponData.Accuracy * 1.2f);
-                            while (foundAmmoAmount > 0)
-                            {
-                                foundAmmoAmount--;
-                                var _orientation = GetRandomOrientation(shotOrientation, scattering);
-                                Mission.AddCustomMissile(shooterAgent, weapon, shotPosition, _orientation.f, _orientation, weaponData.MissileSpeed, weaponData.MissileSpeed, false, null);
-                            }
-                            break;
-                        }
-                    }
-                }
-                else
-                {
-                    if(weapon.CurrentUsageItem!=null)
-                    {
-                        if (weapon.CurrentUsageItem.IsRangedWeapon)
-                        {
-                            if (weapon.CurrentUsageItem.WeaponClass != ammoType)
-                            {
-                                if(weapon.HitPoints>0)
-                                    shooterAgent.SetWeaponAmountInSlot(index,(short) (weapon.HitPoints+1),false);
-                        
-                                var falseMissle= Mission.Missiles.FirstOrDefault(missle => missle.ShooterAgent == shooterAgent);
-                        
-                                if(falseMissle!=null)
-                                    Mission.RemoveMissileAsClient(falseMissle.Index);
-                            }
-                        }
-                    }
-                    
-                    else
-                    {
-                        //TODO maybe check for null current usage 
-                    }
-                }
-
-                
-                
-               
-            }
-
-            
-
-        }
-
+        
         private void DoTwoBarrelsShot(Agent shooterAgent, Vec3 position, Mat3 orientation)
         {
             var weaponData = shooterAgent.WieldedWeapon.CurrentUsageItem;
             var missile = shooterAgent.WieldedWeapon.AmmoWeapon;
             var pos = position;
             pos.y -= 0.1f;
-            Mission.AddCustomMissile(shooterAgent, missile, pos, orientation.f, orientation, weaponData.MissileSpeed, weaponData.MissileSpeed, false, null);
+            Mission.AddCustomMissile(shooterAgent, missile, pos, orientation.f, orientation, weaponData.MissileSpeed,
+                weaponData.MissileSpeed, false, null);
         }
 
         private void DoFourBarrelsShot(Agent shooterAgent, Vec3 position, Mat3 orientation)
         {
             var weaponData = shooterAgent.WieldedWeapon.GetWeaponComponentDataForUsage(0);
             var missile = shooterAgent.WieldedWeapon.AmmoWeapon;
-
             Mat3 orient1 = orientation;
             orient1.RotateAboutUp(10f);
-            Mission.AddCustomMissile(shooterAgent, missile, position, orientation.f, orient1, weaponData.MissileSpeed, weaponData.MissileSpeed, false, null);
-
+            Mission.AddCustomMissile(shooterAgent, missile, position, orientation.f, orient1, weaponData.MissileSpeed,
+                weaponData.MissileSpeed, false, null);
             Mat3 orient2 = orientation;
             orient2.RotateAboutUp(20f);
-            Mission.AddCustomMissile(shooterAgent, missile, position, orientation.f, orient2, weaponData.MissileSpeed, weaponData.MissileSpeed, false, null);
-
+            Mission.AddCustomMissile(shooterAgent, missile, position, orientation.f, orient2, weaponData.MissileSpeed,
+                weaponData.MissileSpeed, false, null);
             Mat3 orient3 = orientation;
             orient3.RotateAboutUp(-15f);
-            Mission.AddCustomMissile(shooterAgent, missile, position, orientation.f, orient3, weaponData.MissileSpeed, weaponData.MissileSpeed, false, null);
+            Mission.AddCustomMissile(shooterAgent, missile, position, orientation.f, orient3, weaponData.MissileSpeed,
+                weaponData.MissileSpeed, false, null);
         }
 
         private Mat3 GetRandomOrientation(Mat3 orientation, float scattering)
@@ -294,16 +181,6 @@ namespace TOW_Core.Battle.FireArms
             float rand3 = MBRandom.RandomFloatRanged(-scattering, scattering);
             orientation.f.RotateAboutZ(rand3);
             return orientation;
-        }
-
-        private void AddMissileScript<TMissileScript>(Mission.Missile grenade, string triggeredEffectName) where TMissileScript : BlackPowderWeaponScript
-        {
-            GameEntity grenadeEntity = grenade.Entity;
-            grenadeEntity.CreateAndAddScriptComponent(typeof(TMissileScript).Name);
-            TMissileScript grenadeScript = grenadeEntity.GetFirstScriptOfType<TMissileScript>();
-            grenadeScript.SetShooterAgent(grenade.ShooterAgent);
-            grenadeScript.SetTriggeredEffect(TriggeredEffectManager.CreateNew(triggeredEffectName));
-            grenadeEntity.CallScriptCallbacks();
         }
     }
 }

--- a/CSharpSourceCode/Battle/BlackPowderWeapon/BlackPowderWeaponMissionLogic.cs
+++ b/CSharpSourceCode/Battle/BlackPowderWeapon/BlackPowderWeaponMissionLogic.cs
@@ -13,9 +13,11 @@ namespace TOW_Core.Battle.FireArms
         private Random _random;
         private bool areEnemiesAlarmed = false;
 
+        private const int availableShotSounds = 5;
+
         public BlackPowderWeaponMissionLogic()
         {
-            for (int i = 0; i < 5; i++)
+            for (int i = 0; i < availableShotSounds; i++)
             {
                 this._soundIndex[i] = SoundEvent.GetEventIdFromString("musket_fire_sound_" + (i + 1));
             }
@@ -87,7 +89,7 @@ namespace TOW_Core.Battle.FireArms
 
         private void SkipReloadPhase(Agent agent, EquipmentIndex index)
         {
-            //this script seem not work as intended the reload phase is not automatically finalized.
+            // TODO this script seem not work as intended the reload phase is not automatically finalized.
             MissionEquipment equipment = agent.Equipment;
             equipment.SetReloadPhaseOfSlot(index, agent.WieldedWeapon.ReloadPhaseCount);
         }
@@ -158,39 +160,7 @@ namespace TOW_Core.Battle.FireArms
                 CreateSmokeParticles(frame, "psys_grenade_explosion_1");
             }
         }
-
-
-
-
-
-        private void DoTwoBarrelsShot(Agent shooterAgent, Vec3 position, Mat3 orientation)
-        {
-            var weaponData = shooterAgent.WieldedWeapon.CurrentUsageItem;
-            var missile = shooterAgent.WieldedWeapon.AmmoWeapon;
-            var pos = position;
-            pos.y -= 0.1f;
-            Mission.AddCustomMissile(shooterAgent, missile, pos, orientation.f, orientation, weaponData.MissileSpeed,
-                weaponData.MissileSpeed, false, null);
-        }
-
-        private void DoFourBarrelsShot(Agent shooterAgent, Vec3 position, Mat3 orientation)
-        {
-            var weaponData = shooterAgent.WieldedWeapon.GetWeaponComponentDataForUsage(0);
-            var missile = shooterAgent.WieldedWeapon.AmmoWeapon;
-            Mat3 orient1 = orientation;
-            orient1.RotateAboutUp(10f);
-            Mission.AddCustomMissile(shooterAgent, missile, position, orientation.f, orient1, weaponData.MissileSpeed,
-                weaponData.MissileSpeed, false, null);
-            Mat3 orient2 = orientation;
-            orient2.RotateAboutUp(20f);
-            Mission.AddCustomMissile(shooterAgent, missile, position, orientation.f, orient2, weaponData.MissileSpeed,
-                weaponData.MissileSpeed, false, null);
-            Mat3 orient3 = orientation;
-            orient3.RotateAboutUp(-15f);
-            Mission.AddCustomMissile(shooterAgent, missile, position, orientation.f, orient3, weaponData.MissileSpeed,
-                weaponData.MissileSpeed, false, null);
-        }
-
+        
         private Mat3 GetRandomOrientation(Mat3 orientation, float scattering)
         {
             float rand1 = MBRandom.RandomFloatRanged(-scattering, scattering);

--- a/CSharpSourceCode/Battle/BlackPowderWeapon/BlackPowderWeaponMissionLogic.cs
+++ b/CSharpSourceCode/Battle/BlackPowderWeapon/BlackPowderWeaponMissionLogic.cs
@@ -1,9 +1,8 @@
-using System;
+﻿using System;
 using TaleWorlds.Engine;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
-using SandBox.Source.Missions;
 using System.Linq;
 using TOW_Core.Battle.TriggeredEffect.Scripts;
 using TOW_Core.Battle.TriggeredEffect;
@@ -15,7 +14,7 @@ namespace TOW_Core.Battle.FireArms
         private int[] _soundIndex = new int[5];
         private Random _random;
         private bool areEnemiesAlarmed = false;
-
+        
         public BlackPowderWeaponMissionLogic()
         {
             for (int i = 0; i < 5; i++)
@@ -24,52 +23,38 @@ namespace TOW_Core.Battle.FireArms
             }
             this._random = new Random();
         }
+        
+
+        private void CreateSmokeParticles(MatrixFrame frame, string particleEffectId)
+        {
+            Mission.AddParticleSystemBurstByName(particleEffectId, frame, false);
+        }
+
+        private void CreateMuzzleFireSound(Vec3 position)
+        {
+            if (this._soundIndex.Length > 0)
+            {
+                int selected = this._random.Next(0, this._soundIndex.Length - 1);
+                Mission.MakeSound(this._soundIndex[selected], position, false, true, -1, -1);
+            }
+        }
+        
 
         public override void OnAgentShootMissile(Agent shooterAgent, EquipmentIndex weaponIndex, Vec3 position, Vec3 velocity, Mat3 orientation, bool hasRigidBody, int forcedMissileIndex)
         {
             var itemUsage = shooterAgent.WieldedWeapon.CurrentUsageItem.ItemUsage;
-            if (shooterAgent.WieldedWeapon.Item.Type == ItemObject.ItemTypeEnum.Thrown)
-            {
-                Mission.Missile grenade = Mission.Missiles.FirstOrDefault(m => m.ShooterAgent == shooterAgent &&
-                                                                               m.Weapon.Item.StringId.Contains("hand_grenade") &&
-                                                                               !m.Entity.HasScriptOfType<HandGrenadeScript>());
-                if (grenade != null)
-                {
-                    AddMissileScript<HandGrenadeScript>(grenade, "grenade_explosion");
-                }
-            }
+            
             if (itemUsage.Contains("handgun") || itemUsage.Contains("pistol"))
             {
                 var frame = new MatrixFrame(orientation, position);
-                // run particles of smoke
-                var offset = (shooterAgent.WieldedWeapon.CurrentUsageItem.WeaponLength + 30) / 100;
-                frame.Advance(offset);
-                Mission.AddParticleSystemBurstByName("handgun_shoot_2", frame, false);
-                // play sound of shot
-                if (this._soundIndex.Length > 0)
-                {
-                    int selected = this._random.Next(0, this._soundIndex.Length - 1);
-                    Mission.MakeSound(this._soundIndex[selected], position, false, true, -1, -1);
-                }
+                frame.Advance((float)(shooterAgent.WieldedWeapon.CurrentUsageItem.WeaponLength/100));
+                CreateSmokeParticles(frame,"handgun_shoot_2");
+                CreateMuzzleFireSound(position);
               
                 // run firearms script
                 if (shooterAgent.WieldedWeapon.Item.StringId.Contains("blunderbuss"))
                 {
-                    if (shooterAgent.WieldedWeapon.AmmoWeapon.Item.StringId.Contains("grenade"))
-                    {
-                        Mission.Missile grenade = Mission.Missiles.FirstOrDefault(m => m.ShooterAgent == shooterAgent &&
-                                                               m.Weapon.Item.StringId.Contains("ammo_grenade") &&
-                                                               !m.Entity.HasScriptOfType<GrenadeScript>());
-                        if (grenade != null)
-                        {
-                            AddMissileScript<GrenadeScript>(grenade, "grenade_explosion");
-                        }
-                    }
-                    else
-                    if(shooterAgent.WieldedWeapon.CurrentUsageItem.WeaponClass == WeaponClass.Crossbow)
-                    {
-                        DoShotgunShot(shooterAgent, position, orientation, 4);
-                    }
+                    DoShotgunShot(shooterAgent,weaponIndex, position, orientation, 6, 4);
                 }
                 else if (shooterAgent.WieldedWeapon.Item.StringId.Contains("two_barrels"))
                 {
@@ -82,46 +67,194 @@ namespace TOW_Core.Battle.FireArms
             }
         }
 
+
+
+        private bool ConsumeAmmoOfAgent(int amount, Agent agent, WeaponClass ammoType)
+        {
+            MissionEquipment equipment = agent.Equipment;
+
+            var d = agent.WieldedWeapon.CurrentUsageIndex;
+            
+            
+
+            EquipmentIndex equipmentIndex =(EquipmentIndex) equipment.GetAmmoSlotIndexOfWeapon(ammoType);
+
+            var currentAmmo = equipment.GetAmmoAmount(ammoType);
+
+            if (currentAmmo >= amount)
+            {
+                short newAmount = (short)(currentAmmo - amount);
+                //equipment.SetHitPointsOfSlot(equipmentIndex,newAmount);
+                //equipment.SetHitPointsOfSlot((EquipmentIndex)d,newAmount);
+                //equipment.SetAmountOfSlot((EquipmentIndex)d, newAmount,false);
+                //equipment.SetAmountOfSlot(equipmentIndex,newAmount,false);
+               //equipment.SetConsumedAmmoOfSlot(equipmentIndex, (short) amount);
+                //agent.WieldedWeapon.ConsumeAmmo((short)amount);
+                
+                agent.SetWeaponAmountInSlot(equipmentIndex,newAmount,false);
+               // agent.WieldedWeapon.AmmoWeapon.ConsumeAmmo();
+                return true;
+            }
+
+            return false;
+        }
+
+        private void RestoreAmmo(Agent agent, WeaponClass ammoType)
+        {
+            MissionEquipment equipment = agent.Equipment;
+            EquipmentIndex equipmentIndex =(EquipmentIndex) equipment.GetAmmoSlotIndexOfWeapon(ammoType);
+            short restoredAmmo = (short) (equipment.GetAmmoAmount(ammoType)+1);
+            agent.SetWeaponAmountInSlot(equipmentIndex,restoredAmmo,false);
+        }
+
         /// <summary>
         /// The script will check each ammo weapon (that fits current usage of shooter's weapon) for bullets to do blunderbuss shot. 
         /// It can use multiple ammo weapons to collect required amount of bullets.
         /// </summary>
         /// <param name="requiredAmmoAmount">Max amount of bullets to do blunderbuss shot.</param>
-        private void DoShotgunShot(Agent shooterAgent, Vec3 shotPosition, Mat3 shotOrientation, short requiredAmmoAmount)
+        ///
+        ///
+        private void DoShotgunShot(Agent shooterAgent,EquipmentIndex weaponIndex,Vec3 shotPosition ,Mat3 shotOrientation, short scatterShots, short requiredAmmoAmount)
         {
-            MissionWeapon weapon = MissionWeapon.Invalid;
-            short foundAmmoAmount = 0;
-            for (EquipmentIndex index = EquipmentIndex.WeaponItemBeginSlot; index < EquipmentIndex.NumAllWeaponSlots; index++)
+            MissionWeapon weaponAtIndex = shooterAgent.Equipment[weaponIndex];
+
+            var weaponData = weaponAtIndex.CurrentUsageItem;
+            
+            if (weaponData!=null&&weaponAtIndex.CurrentUsageItem.IsRangedWeapon)
             {
-                weapon = shooterAgent.Equipment[index];
-                // Weapon hit points mean amount of ammo
-                if(weapon.CurrentUsageItem==null)
-                    continue;
-                
-                if (weapon.CurrentUsageItem.WeaponClass == shooterAgent.WieldedWeapon.CurrentUsageItem.AmmoClass && weapon.HitPoints > 0)
+            
+                RemoveLastProjectile(shooterAgent);
+                RestoreAmmo(shooterAgent,weaponData.AmmoClass);
+                if (!weaponAtIndex.AmmoWeapon.IsEmpty)
                 {
-                    foundAmmoAmount += Math.Min(requiredAmmoAmount, weapon.HitPoints);
-                    short newAmount = (short)(weapon.HitPoints - Math.Min(foundAmmoAmount, weapon.HitPoints));
-                    shooterAgent.SetWeaponAmountInSlot(index, newAmount, false);
-                    if (foundAmmoAmount == requiredAmmoAmount)
+                    var accuracy = 1f / (weaponData.Accuracy * 1.2f);
+                    /*MissionEquipment equipment = shooterAgent.Equipment;
+                    var t = equipment.GetAmmoAmount(weaponData.AmmoClass);
+                    EquipmentIndex index = (EquipmentIndex) equipment.GetAmmoSlotIndexOfWeapon(weaponData.AmmoClass);
+                    equipment.SetHitPointsOfSlot(index,(short) (equipment[index].HitPoints- requiredAmmoAmount));*/
+
+                    if (ConsumeAmmoOfAgent(requiredAmmoAmount, shooterAgent, weaponData.AmmoClass))
                     {
-                        break;
-                    }
-                    else
-                    {
-                        continue;
+                        ScatterShot(shooterAgent,accuracy,weaponAtIndex.AmmoWeapon,shotPosition,shotOrientation,scatterShots, 1.2f,weaponData.MissileSpeed);
                     }
                 }
+               
+                
+                /*float scattering = 1f / (weaponData.Accuracy * 1.2f);
+                while (foundAmmoAmount > 0)
+                {
+                    foundAmmoAmount--;
+                    var _orientation = GetRandomOrientation(shotOrientation, scattering);
+                    Mission.AddCustomMissile(shooterAgent, weapon, shotPosition, _orientation.f, _orientation, weaponData.MissileSpeed, weaponData.MissileSpeed, false, null);
+                }
+              
+                
+                if (foundAmmoAmount == requiredAmmoAmount)
+                {
+                            
+                    
+                }
+                TOWCommon.Say(ammo.ToString());*/
+            }
+        }
+        
+        
+
+
+        private void ScatterShot(Agent shooterAgent, float accuracy, MissionWeapon ammo, Vec3 shotPosition, Mat3 shotOrientation, short scatterShots, float scatteringDeviation, float missleSpeed)
+        {
+            for (int i = 0; i < scatterShots; i++)
+            {
+                var deviation  = GetRandomOrientation(shotOrientation, accuracy);
+                Mission.AddCustomMissile(shooterAgent, ammo, shotPosition, deviation.f, deviation, missleSpeed, missleSpeed, false, null);
+            }
+        }
+
+        /*private void SetAmmunition(Agent shooterAgent, MissionWeapon rangedWeapon, short ammo, bool IsLoaded)
+        {
+            shooterAgent.Character.Equipment.GetEquipmentFromSlot()
+            var ammoIndex = rangedWeapon.AmmoWeapon.CurrentUsageIndex;
+            var lastStage = rangedWeapon.ReloadPhaseCount;
+            shooterAgent.SetReloadAmmoInSlot(index,ammoIndex,ammo);
+            shooterAgent.SetWeaponReloadPhaseAsClient(index, lastStage);
+            rangedWeapon.;
+        }*/
+
+        private void RemoveLastProjectile(Agent shooterAgent)
+        {
+            var falseMissle= Mission.Missiles.FirstOrDefault(missle => missle.ShooterAgent == shooterAgent);
+                        
+                if(falseMissle!=null)
+                    Mission.RemoveMissileAsClient(falseMissle.Index);
+        }
+        private void DoShotgunShot(Agent shooterAgent, Vec3 shotPosition, Mat3 shotOrientation, short requiredAmmoAmount, WeaponClass ammoType =WeaponClass.Cartridge)
+        {
+            short foundAmmoAmount = 0;
+            
+           
+            for (EquipmentIndex index = EquipmentIndex.WeaponItemBeginSlot; index < EquipmentIndex.NumAllWeaponSlots; index++)
+            {
+                var weapon = shooterAgent.Equipment[index];
+
+               
+                
+                if (weapon.CurrentUsageItem!=null && weapon.CurrentUsageItem.WeaponClass == ammoType)
+                {
+                    WeaponComponentData weaponData = shooterAgent.WieldedWeapon.CurrentUsageItem;
+                    // Weapon hit points mean amount of ammo
+
+                    if (weapon.CurrentUsageItem.WeaponClass == WeaponClass.Cartridge && weapon.HitPoints > 0)
+                    {
+                        foundAmmoAmount += Math.Min(requiredAmmoAmount, weapon.HitPoints);
+                        short newAmount = (short)(weapon.HitPoints - Math.Min(foundAmmoAmount, weapon.HitPoints));
+                        
+                       // shooterAgent.SetReloadAmmoInSlot(index,);
+                        shooterAgent.SetWeaponAmountInSlot(index, newAmount, false);
+                        if (foundAmmoAmount == requiredAmmoAmount)
+                        {
+                            
+                            float scattering = 1f / (weaponData.Accuracy * 1.2f);
+                            while (foundAmmoAmount > 0)
+                            {
+                                foundAmmoAmount--;
+                                var _orientation = GetRandomOrientation(shotOrientation, scattering);
+                                Mission.AddCustomMissile(shooterAgent, weapon, shotPosition, _orientation.f, _orientation, weaponData.MissileSpeed, weaponData.MissileSpeed, false, null);
+                            }
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    if(weapon.CurrentUsageItem!=null)
+                    {
+                        if (weapon.CurrentUsageItem.IsRangedWeapon)
+                        {
+                            if (weapon.CurrentUsageItem.WeaponClass != ammoType)
+                            {
+                                if(weapon.HitPoints>0)
+                                    shooterAgent.SetWeaponAmountInSlot(index,(short) (weapon.HitPoints+1),false);
+                        
+                                var falseMissle= Mission.Missiles.FirstOrDefault(missle => missle.ShooterAgent == shooterAgent);
+                        
+                                if(falseMissle!=null)
+                                    Mission.RemoveMissileAsClient(falseMissle.Index);
+                            }
+                        }
+                    }
+                    
+                    else
+                    {
+                        //TODO maybe check for null current usage 
+                    }
+                }
+
+                
+                
+               
             }
 
-            WeaponComponentData weaponData = shooterAgent.WieldedWeapon.CurrentUsageItem;
-            float scattering = 1f / (weaponData.Accuracy * 1.2f);
-            while (foundAmmoAmount > 0)
-            {
-                foundAmmoAmount--;
-                var _orientation = GetRandomOrientation(shotOrientation, scattering);
-                Mission.AddCustomMissile(shooterAgent, weapon, shotPosition, _orientation.f, _orientation, weaponData.MissileSpeed, weaponData.MissileSpeed, false, null);
-            }
+            
 
         }
 

--- a/CSharpSourceCode/Quests/HideoutAlertMissionLogic.cs
+++ b/CSharpSourceCode/Quests/HideoutAlertMissionLogic.cs
@@ -1,0 +1,34 @@
+﻿using SandBox.Source.Missions;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+
+namespace TOW_Core.Quests
+{
+    public class HideoutAlertMissionLogic : MissionLogic
+    {
+
+        private bool _enemiesAreAlarmed = true;
+        
+        public override void OnAgentShootMissile(Agent shooterAgent, EquipmentIndex weaponIndex, Vec3 position, Vec3 velocity, Mat3 orientation,
+            bool hasRigidBody, int forcedMissileIndex)
+        {
+            base.OnAgentShootMissile(shooterAgent, weaponIndex, position, velocity, orientation, hasRigidBody, forcedMissileIndex);
+
+
+            if (_enemiesAreAlarmed) return;
+            
+            var itemUsage = shooterAgent.WieldedWeapon.CurrentUsageItem.ItemUsage;
+            if (!itemUsage.Contains("handgun") && !itemUsage.Contains("pistol")) return;
+                
+            var hideoutMissionController = Mission.Current.GetMissionBehavior<HideoutMissionController>();
+            if (hideoutMissionController == null) return;
+            foreach (var agent in base.Mission.PlayerEnemyTeam.TeamAgents)
+            {
+                hideoutMissionController.OnAgentAlarmedStateChanged(agent, Agent.AIStateFlag.Alarmed);
+                agent.SetWatchState(Agent.WatchState.Alarmed);
+            }
+            _enemiesAreAlarmed=true;
+        }
+    }
+}


### PR DESCRIPTION
Important: Requires to also check out a branch in Armory.

This will not be really tested in the game now but is the approach I want to take to the 1.80 Repo.

Changes: 
Separated Logic for shotgun ammunition management and the actual scattershot.

Proper management for Ammo reduction. If not enough ammo is available the shot is aborted.

Revised scattershot logic for a proper shot distribution

Removed double shots and four shots, since after discussion with lore that's too rare to be considered. Would however follow the same logic as the shotgun logic.

Reworked grenade launcher to be purely XML based with only particles are added on missle collision

Moved Alert of People to a Missionlogic that purely works for hideouts.

Note:

String-based comparisons are expensive, and we need to find a better way to do this in future

I am not sure if it's less expensive to initiate a new script or check on collision for the right ammo type ( in the case of the grenade launcher). Would be nice to get here input of yours. 